### PR TITLE
Provide a valid subject when pushing event data.

### DIFF
--- a/libraries/coscale.rb
+++ b/libraries/coscale.rb
@@ -71,7 +71,7 @@ class Chef
     def self._eventdatapush(message, timestamp, token, url)
       data = {'message' => message,
               'timestamp' => timestamp,
-              'subject' => 'subject',
+              'subject' => 'a',
               }
       headers = {'HTTPAuthorization' => token}
 


### PR DESCRIPTION
"subject" should either be the short of the server or group, or be "a" for application wide.
